### PR TITLE
Add to_string !eval tag

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -173,10 +173,13 @@ Examples and tutorials can be found in link:examples[examples] folder.
 |param_configuration.configuration.get_resolved_yaml
 |Resolves the given YAML file and returns a path to it.
 
+|!eval to_string()
+|str()
+|Converts the given value to a string. Handy when using nested evaluations.
+
 |!eval var.<var_name>
 |-
 |Allows using variables which are defined in the beginning of the same file, under ".variables" -key. This key will be removed from the result file.
-
 |===
 
 

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -78,6 +78,38 @@ def test_eval_tag_from_string(yaml_string: str) -> None:
         assert data_str == expected_str
 
 
+def test_eval_round() -> None:
+    """Test the !eval directive with the round function."""
+    yaml_string = """
+    round: !eval round(3.141592653589793, 2)
+    """
+    expected_string = "round: 3.14"
+
+    configuration = Configuration()
+    data = configuration.load(yaml_string)
+    data_str = configuration.dump(data)
+    assert data_str == expected_string
+
+
+def test_eval_to_string() -> None:
+    """Test the !eval directive with the to_string function."""
+    yaml_string = """
+    float_to_string: !eval to_string(3.141592653589793)
+    array_to_string: !eval to_string([[1.0, 1.0], [2.0, 2.0]])
+    """
+    # fmt: off
+    expected_string = (
+        "float_to_string: '3.141592653589793'\n"
+        "array_to_string: '[[1.0, 1.0], [2.0, 2.0]]'"
+    )
+    # fmt: on
+
+    configuration = Configuration()
+    data = configuration.load(yaml_string)
+    data_str = configuration.dump(data)
+    assert data_str == expected_string
+
+
 def test_eval_small_numbers() -> None:
     """Test the loading and dumping !eval directive from a string."""
     configuration = Configuration()


### PR DESCRIPTION
Adds a `to_string` function for `!eval` tag.

Goal of this addition is shown by the new test. To achieve this, a support for lists had to be added. This was done by using `EvalWithCompoundTypes` object instead of the `SimpleEval` object.

[[1.0, 1.0], [2.0, 2.0]] -> '[[1.0, 1.0], [2.0, 2.0]]'