### PR TITLE
Add overlay append command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,7 +47,11 @@ The overlaying will automatically look for parameter files across three differen
 * Model level
 * ROS Package level
 
-For example, any parameter that is set in Device level configuration, will override Model level and ROS Package level configurations. Overlaying files need to have `!overlay` tag in the beginning of the file, otherwise it won't be overlaid with a level below. Check out the tutorials in link:examples[examples] folder.
+For example, any parameter that is set in Device level configuration, will override Model level and ROS Package level configurations.
+
+**Tags:**
+- `!overlay`: Set in the beginning of the file, to overlay the file with a layer below. Check out the tutorials in link:examples[examples] folder.
+- `!overlay_append`: Similar to `!overlay`, but instead of replacing the YAML sequences (lists), appends to them.
 
 This level structure is also extendable, so that you can have your custom configuration for the overlaying levels.
 

--- a/param_configuration/__init__.py
+++ b/param_configuration/__init__.py
@@ -21,3 +21,4 @@ from param_configuration.tags.from_config import FromConfigConstructor  # noqa
 from param_configuration.tags.include import IncludeConfigConstructor  # noqa
 from param_configuration.tags.merge import MergeMultiConfigConstructor  # noqa
 from param_configuration.tags.overlay import OverlayConfigConstructor  # noqa
+from param_configuration.tags.overlay_append import OverlayAppendConfigConstructor  # noqa

--- a/param_configuration/configuration.py
+++ b/param_configuration/configuration.py
@@ -16,7 +16,6 @@
 import io
 import pathlib
 import tempfile
-
 from abc import abstractmethod
 from pathlib import Path
 from typing import Any, Optional, Type, Union

--- a/param_configuration/configuration.py
+++ b/param_configuration/configuration.py
@@ -13,9 +13,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #  ------------------------------------------------------------------
+import io
 import pathlib
 import tempfile
-import io
 
 from abc import abstractmethod
 from pathlib import Path

--- a/param_configuration/tags/overlay_append.py
+++ b/param_configuration/tags/overlay_append.py
@@ -1,0 +1,41 @@
+#  ------------------------------------------------------------------
+#   Copyright 2024 Karelics Oy
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#  ------------------------------------------------------------------
+# Thirdparty
+from ruamel.yaml import BaseConstructor
+
+# Parameter Configuration
+from param_configuration.configuration import ConfigConstructor, Configuration
+from param_configuration.utils import merge_left
+
+# pylint: disable=too-few-public-methods
+# Fine for inheritance
+
+
+class OverlayAppendConfigConstructor(ConfigConstructor, tag="!overlay_append"):
+    """The !overlay_append is otherwise same as !overlay, but instead of replacing sequences, appends them."""
+
+    def constructor(self, tag_value: str, file: str, loader: BaseConstructor):
+        underlay = Configuration().load(self.file, config_layers=self.config_layers[1:])
+        for i in tag_value:
+            merge_left(underlay, i, append=True)
+        return underlay
+
+    def __call__(self, loader, node):
+        items = list(loader.construct_yaml_map(node=node))
+        return self.constructor(tag_value=items, file=node.end_mark.name, loader=loader)
+
+
+Configuration().add_config_constructor(const=OverlayAppendConfigConstructor)

--- a/param_configuration/utils.py
+++ b/param_configuration/utils.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Dict
 
 
-def merge_left(keys_a, keys_b, path=None):
+def merge_left(keys_a, keys_b, path=None, append=False):
     """Merges b into a where b overwrites a."""
     if path is None:
         path = []
@@ -26,6 +26,11 @@ def merge_left(keys_a, keys_b, path=None):
         if key in keys_a:
             if isinstance(keys_a[key], dict) and isinstance(keys_b[key], dict):
                 merge_left(keys_a[key], keys_b[key], path + [str(key)])
+            elif append and isinstance(keys_a[key], list) and isinstance(keys_b[key], list):
+                # If we are in "append" mode, append all the sequences instead of replacing them
+                for appended_key in keys_b[key]:
+                    if appended_key not in keys_a[key]:
+                        keys_a[key] += keys_b[key]
             else:
                 keys_a[key] = keys_b[key]
         else:

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -493,6 +493,7 @@ named_sequence:
                 "new_sequence": [1],
             }
 
+
 @mock.patch.dict(os.environ, {"PARAM_DEVICE_DIR": "device"})
 def test_overlay_append_empty_device_config(tmp_path: Path) -> None:
     """Make sure that the sequence appending works correctly when we have empty "device".

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -426,6 +426,123 @@ var5: "package_level_var5"
             }
 
 
+@mock.patch.dict(os.environ, {"PARAM_DEVICE_DIR": "device"})
+def test_overlay_append(tmp_path: Path) -> None:
+    """Test that overlay_append correctly appends sequences.
+    """
+    package_name = "test_package"
+
+    # This file exist on device / model and package level
+    test_file_1 = "test_file1.yaml"
+
+    device_data = f"""
+!overlay_append
+var1: "device_level_1"
+var2: "device_level_2"
+sequence: [3]
+new_sequence:
+  - 1
+named_sequence:
+  - val_1: 1000
+    val_2: 2000
+"""
+
+    model_data_1 = """
+!overlay_append
+var1: "model_level_1"
+"""
+
+    package_data_1 = """
+var1: "package_level_var3"
+sequence: [0, 1, 2]
+named_sequence:
+  - val_1: 1
+    val_2: 2
+  - val_1: 100
+    val_2: 200
+"""
+
+    # Create a device directory and add file
+    write_to_file_config_layer(device_data, "device", package_name, test_file_1, tmp_path)
+
+    # Create a model directory and add files
+    write_to_file_config_layer(model_data_1, "model", package_name, test_file_1, tmp_path)
+
+    # Create a package directory and add file
+    package_dir = tmp_path / "test_install_space/"
+    (package_dir / package_name / "params/").mkdir(parents=True, exist_ok=True)
+    package_param_file = package_dir / package_name
+    (package_param_file / "params/test_file1.yaml").write_text(package_data_1)
+
+    with mock.patch(
+        "param_configuration.config_layers.ros_package.get_package_share_directory",
+        return_value=str(package_param_file),
+    ):
+        # Set the param config directory to a tmp directory
+        with TempConfigEnv(path=tmp_path):
+            configuration = Configuration()
+            data = configuration.load(f"config://{package_name}/{test_file_1}")
+            assert data == {
+                "var1": "device_level_1",
+                "sequence": [0, 1, 2, 3],
+                "named_sequence": [{'val_1': 1, 'val_2': 2}, {'val_1': 100, 'val_2': 200}, {'val_1': 1000, 'val_2': 2000}],
+                "var2": "device_level_2",
+                "new_sequence": [1],
+            }
+
+@mock.patch.dict(os.environ, {"PARAM_DEVICE_DIR": "device"})
+def test_overlay_append_empty_device_config(tmp_path: Path) -> None:
+    """
+    Make sure that the sequence appending works correctly when we have empty "device". Previously,
+    this wasn't working as expected, and ended up always adding again the appended sequence.
+    """
+    package_name = "test_package"
+
+    # This file exist on device / model and package level
+    test_file_1 = "test_file1.yaml"
+
+    model_data_1 = """
+!overlay_append
+var1: "model_level_1"
+named_sequence:
+  - val_1: 1000
+    val_2: 2000
+"""
+
+    package_data_1 = """
+var1: "package_level_var3"
+sequence: [0, 1, 2]
+named_sequence:
+  - val_1: 1
+    val_2: 2
+  - val_1: 100
+    val_2: 200
+"""
+
+    # Create a model directory and add files
+    write_to_file_config_layer(model_data_1, "model", package_name, test_file_1, tmp_path)
+
+    # Create a package directory and add file
+    package_dir = tmp_path / "test_install_space/"
+    (package_dir / package_name / "params/").mkdir(parents=True, exist_ok=True)
+    package_param_file = package_dir / package_name
+    (package_param_file / "params/test_file1.yaml").write_text(package_data_1)
+
+    with mock.patch(
+        "param_configuration.config_layers.ros_package.get_package_share_directory",
+        return_value=str(package_param_file),
+    ):
+        # Set the param config directory to a tmp directory
+        with TempConfigEnv(path=tmp_path):
+            configuration = Configuration()
+            data = configuration.load(f"config://{package_name}/{test_file_1}")
+            assert data == {
+                "var1": "model_level_1",
+                "sequence": [0, 1, 2],
+                "named_sequence": [{'val_1': 1, 'val_2': 2}, {'val_1': 100, 'val_2': 200}, {'val_1': 1000, 'val_2': 2000}],
+            }
+
+
 def write_to_file_config_layer(data, level, package_name, file_name, config_base_dir):
     """Creates necessary folders and writes the file."""
     device_dir = config_base_dir / f"{level}/"

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -487,7 +487,7 @@ named_sequence:
                 "named_sequence": [
                     {'val_1': 1, 'val_2': 2},
                     {'val_1': 100, 'val_2': 200},
-                    {'val_1': 1000, 'val_2': 2000}
+                    {'val_1': 1000, 'val_2': 2000},
                 ],
                 "var2": "device_level_2",
                 "new_sequence": [1],
@@ -545,7 +545,7 @@ named_sequence:
                 "named_sequence": [
                     {'val_1': 1, 'val_2': 2},
                     {'val_1': 100, 'val_2': 200},
-                    {'val_1': 1000, 'val_2': 2000}
+                    {'val_1': 1000, 'val_2': 2000},
                 ],
             }
 

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -485,9 +485,9 @@ named_sequence:
                 "var1": "device_level_1",
                 "sequence": [0, 1, 2, 3],
                 "named_sequence": [
-                    {'val_1': 1, 'val_2': 2},
-                    {'val_1': 100, 'val_2': 200},
-                    {'val_1': 1000, 'val_2': 2000},
+                    {"val_1": 1, "val_2": 2},
+                    {"val_1": 100, "val_2": 200},
+                    {"val_1": 1000, "val_2": 2000},
                 ],
                 "var2": "device_level_2",
                 "new_sequence": [1],
@@ -543,9 +543,9 @@ named_sequence:
                 "var1": "model_level_1",
                 "sequence": [0, 1, 2],
                 "named_sequence": [
-                    {'val_1': 1, 'val_2': 2},
-                    {'val_1': 100, 'val_2': 200},
-                    {'val_1': 1000, 'val_2': 2000},
+                    {"val_1": 1, "val_2": 2},
+                    {"val_1": 100, "val_2": 200},
+                    {"val_1": 1000, "val_2": 2000},
                 ],
             }
 

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -428,14 +428,13 @@ var5: "package_level_var5"
 
 @mock.patch.dict(os.environ, {"PARAM_DEVICE_DIR": "device"})
 def test_overlay_append(tmp_path: Path) -> None:
-    """Test that overlay_append correctly appends sequences.
-    """
+    """Test that overlay_append correctly appends sequences."""
     package_name = "test_package"
 
     # This file exist on device / model and package level
     test_file_1 = "test_file1.yaml"
 
-    device_data = f"""
+    device_data = """
 !overlay_append
 var1: "device_level_1"
 var2: "device_level_2"
@@ -485,16 +484,20 @@ named_sequence:
             assert data == {
                 "var1": "device_level_1",
                 "sequence": [0, 1, 2, 3],
-                "named_sequence": [{'val_1': 1, 'val_2': 2}, {'val_1': 100, 'val_2': 200}, {'val_1': 1000, 'val_2': 2000}],
+                "named_sequence": [
+                    {'val_1': 1, 'val_2': 2},
+                    {'val_1': 100, 'val_2': 200},
+                    {'val_1': 1000, 'val_2': 2000}
+                ],
                 "var2": "device_level_2",
                 "new_sequence": [1],
             }
 
 @mock.patch.dict(os.environ, {"PARAM_DEVICE_DIR": "device"})
 def test_overlay_append_empty_device_config(tmp_path: Path) -> None:
-    """
-    Make sure that the sequence appending works correctly when we have empty "device". Previously,
-    this wasn't working as expected, and ended up always adding again the appended sequence.
+    """Make sure that the sequence appending works correctly when we have empty "device".
+
+    Previously, this wasn't working as expected, and ended up always adding again the appended sequence.
     """
     package_name = "test_package"
 
@@ -539,7 +542,11 @@ named_sequence:
             assert data == {
                 "var1": "model_level_1",
                 "sequence": [0, 1, 2],
-                "named_sequence": [{'val_1': 1, 'val_2': 2}, {'val_1': 100, 'val_2': 200}, {'val_1': 1000, 'val_2': 2000}],
+                "named_sequence": [
+                    {'val_1': 1, 'val_2': 2},
+                    {'val_1': 100, 'val_2': 200},
+                    {'val_1': 1000, 'val_2': 2000}
+                ],
             }
 
 


### PR DESCRIPTION
There wasn't a way to append to existing lists (YAML sequences). This PR brings in `!overlay_append` command, that lets to append to overlaid lists, rather than to fully replace them.